### PR TITLE
WIP add logic to provide configuration for promise timeouts during a request

### DIFF
--- a/lib/marathon.js
+++ b/lib/marathon.js
@@ -45,18 +45,10 @@ function Marathon(baseUrl, opts) {
     }
 
     function makeRequest(method, path, addOptions, requestStream) {
+        addOptions || (addOptions = {})
         return function closure(query, body) {
-            var requestOptions = _.cloneDeep(baseOptions);
-
-            requestOptions.method = method;
-            requestOptions.qs = query;
-            requestOptions.url = nodeUrl.format(getRequestUrl(path));
-
-            if (addOptions) {
-                requestOptions = _.extend(requestOptions, addOptions);
-            }
-
-            requestOptions.body = body;
+            var requestTimeout = ('timeout' in addOptions) ? addOptions.timeout : 0 // set a 0 timeout value and if it gets increased we'll use it
+            var requestOptions = _.extend({},_.cloneDeep(baseOptions),_.omit(addOptions,'timeout'),{method: method,qs: query,url: nodeUrl.format(getRequestUrl(path)),body: body})
 
             var consoleTimeToken = 'Request to Marathon ' + path;
 
@@ -71,7 +63,7 @@ function Marathon(baseUrl, opts) {
             }
 
             if (requestStream) {
-                return new Promise(function createPromise(resolve, reject) {
+                var rv = new Promise(function createPromise(resolve, reject) {
                     request[method.toLowerCase()](requestOptions)
                         .on('error', function onError(err) {
                             return reject(err);
@@ -83,9 +75,11 @@ function Marathon(baseUrl, opts) {
                             return resolve(readableStream);
                         });
                 });
+                if (requestTimeout > 0) return rv.timeout(requestTimeout)
+                return rv
             }
 
-            return rp(requestOptions).finally(logTime);
+            return rp(requestOptions).timeout(requestTimeout).finally(logTime);
         };
     }
 


### PR DESCRIPTION
Adds some logic to timeout promises on an as needed basis by accepting a timeout option in `addOptions` for `makeRequest`