### PR TITLE
event source subscription fails when specifying interesting event types

### DIFF
--- a/api/events.js
+++ b/api/events.js
@@ -4,24 +4,27 @@ var EventSource = require('eventsource')
 
 class MarathonEventSource {
   constructor (ctx) { // accepts a parent context
-    this.parent = ctx
+    this.basePath = ctx.basePath
     this.baseURL = ctx.baseURL
     this.baseURL.pathname = this.path
     this.client = ctx.http
     this.client.defaults.baseURL = this.baseURL.toString()
   }
 
-  get path () { return `${this.parent.basePath}/events` }
+  get path () { return `${this.basePath}/events` }
 
   // the constructor url should contain credentials and the api basepath '/v2'
   createEventSource (opts = {}) {
+    this.baseURL.pathname = this.path // make sure we have a good path
     const { eventType } = opts
     if (eventType) {
-      if (!((eventType instanceof String) || (eventType instanceof Array))) {
+      if (typeof eventType === 'string') {
+        this.baseURL.searchParams.set('event_type', eventType)
+      } else if (eventType instanceof Array) { // array
+        for (const type of eventType) { this.baseURL.searchParams.append('event_type', type) }
+      } else {
         throw new Error('"eventType" should be an array or string')
       }
-      this.baseURL.searchParams.set('event_type', eventType)
-      this.baseURL.pathname = this.path
     }
     this.es = new EventSource(`${this.baseURL}`)
     return this.es

--- a/api/events.js
+++ b/api/events.js
@@ -6,10 +6,12 @@ class MarathonEventSource {
   constructor (ctx) { // accepts a parent context
     this.parent = ctx
     this.baseURL = ctx.baseURL
-    this.baseURL.pathname = `${ctx.basePath}/events`
+    this.baseURL.pathname = this.path
     this.client = ctx.http
     this.client.defaults.baseURL = this.baseURL.toString()
   }
+
+  get path () { return `${this.parent.basePath}/events` }
 
   // the constructor url should contain credentials and the api basepath '/v2'
   createEventSource (opts = {}) {
@@ -19,6 +21,7 @@ class MarathonEventSource {
         throw new Error('"eventType" should be an array or string')
       }
       this.baseURL.searchParams.set('event_type', eventType)
+      this.baseURL.pathname = this.path
     }
     this.es = new EventSource(`${this.baseURL}`)
     return this.es

--- a/api/events.js
+++ b/api/events.js
@@ -22,9 +22,7 @@ class MarathonEventSource {
         this.baseURL.searchParams.set('event_type', eventType)
       } else if (eventType instanceof Array) { // array
         for (const type of eventType) { this.baseURL.searchParams.append('event_type', type) }
-      } else {
-        throw new Error('"eventType" should be an array or string')
-      }
+      } // ignore anything that isn't a string or array
     }
     this.es = new EventSource(`${this.baseURL}`)
     return this.es

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marathon-node",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Node.js client library for Mesos Marathon's REST API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There are 2 issues in v2.0.0 that are remediated in this release.
1. The `baseURL` parameter we are using seems to be a copy of the parent object and changes when leader lookup is done
2. The URLSearchParams.set() command malforms the data